### PR TITLE
Fixing retrieving non-ascii string with JSON.GET, added no_escape flag

### DIFF
--- a/rejson/__init__.py
+++ b/rejson/__init__.py
@@ -47,6 +47,14 @@ jp = rj.pipeline()
 jp.set('foo', 'bar')
 jp.jsonset('baz', Path.rootPath(), 'qaz')
 jp.execute()
+
+# If you use non-ascii character in your JSON data, you can add the no_escape flag to JSON.GET command
+obj_non_ascii = {
+    'non_ascii_string': 'hyvää'
+    }
+
+rj.jsonset('non-ascii', Path.rootPath(), obj_non_ascii)
+print '{} is a non-ascii string'.format(rj.jsonget('non-ascii', Path('.non_ascii_string'), no_escape=True))
 ```
 
 ## Encoding/Decoding

--- a/rejson/client.py
+++ b/rejson/client.py
@@ -103,14 +103,19 @@ class Client(StrictRedis):
         """
         return self.execute_command('JSON.DEL', name, str_path(path))
 
-    def jsonget(self, name, *args):
+    def jsonget(self, name, *args, no_escape=False):
         """
         Get the object stored as a JSON value at key ``name``
         ``args`` is zero or more paths, and defaults to root path
+        ```no_escape`` is a boolean flag to add no_escape option to get non-ascii characters
         """
         pieces = [name]
+        if no_escape:
+            pieces.append('noescape')
+
         if len(args) == 0:
             pieces.append(Path.rootPath())
+
         else:
             for p in args:
                     pieces.append(str_path(p))

--- a/tests/test_rejson.py
+++ b/tests/test_rejson.py
@@ -4,7 +4,6 @@ import unittest
 from unittest import TestCase
 from rejson import Client, Path
 
-
 rj = None
 port = 6379
 
@@ -24,6 +23,15 @@ class ReJSONTestCase(TestCase):
         self.assertEqual(None, rj.jsonget('baz'))
         self.assertEqual(1, rj.jsondel('foo'))
         self.assertFalse(rj.exists('foo'))
+
+    def testJSONSetGetDelNonAsciiShouldSucceed(self):
+        "Test non-ascii JSONSet/Get/Del"
+
+        self.assertTrue(rj.jsonset('notascii', Path.rootPath(), 'hyvää-élève'))
+        self.assertNotEqual('hyvää-élève', rj.jsonget('notascii'))
+        self.assertEqual('hyvää-élève', rj.jsonget('notascii', no_escape=True))
+        self.assertEqual(1, rj.jsondel('notascii'))
+        self.assertFalse(rj.exists('notascii'))
 
     def testJSONSetExistentialModifiersShouldSucceed(self):
         "Test JSONSet's NX/XX flags"


### PR DESCRIPTION
Trying to solve the issue which comes from ReJSON itself as talked about in #19.
This pull request adds the `no_escape` boolean flag to the JSON.GET command, to retrieve non-ascii characters. This flag has been added as a fix in ReJSON and has been discussed in the issue RedisJSON/RedisJSON#98

It should be covered by the new tests, I didn't generate the new API.md file as I don't use python2.