### PR TITLE
Updated README.rst with example of no_escape flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,12 @@ Usage example
    jp.jsonset('baz', Path.rootPath(), 'qaz')
    jp.execute()
 
+   # If you use non-ascii character in your JSON data, you can add the no_escape flag to JSON.GET command
+   obj_non_ascii = {
+     'non_ascii_string': 'hyvää'
+   }
+   rj.jsonset('non-ascii', Path.rootPath(), obj_non_ascii)
+   print '{} is a non-ascii string'.format(rj.jsonget('non-ascii', Path('.non_ascii_string'), no_escape=True))
 
 Encoding/Decoding
 -----------------


### PR DESCRIPTION
Hello,
I realised that I forgot to update the README with the new change. I updated the \_\_init\_\_.py file, thinking that it would auto-generate the README. This pull request adds the example that was missing. Apologies!