### PR TITLE
Use io.open() and 'utf-8' to read description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def get_version(package):
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
 def read_all(f):
-    with open(f) as I:
+    with io.open(f, encoding="utf-8") as I:
         return I.read()
 
 requirements = map(str.strip, open("requirements.txt").readlines())


### PR DESCRIPTION
Extra fix for https://github.com/RedisJSON/redisjson-py/issues/28 to eliminate FreeBSD 12 + Python 3.6.1 UnicodeDecodeError upon installation.