### PR TITLE
#39 - Let's discuss the approach and tests

### DIFF
--- a/rejson/__init__.py
+++ b/rejson/__init__.py
@@ -120,6 +120,6 @@ rj.jsonset('custom', Path.rootPath(), obj))
 obj = rj.jsonget('custom', Path.rootPath())
 ```
 """
-__version__ = "0.5.4"
+__version__ = "0.6.0-alpha"
 from .client import Client
 from .path import Path

--- a/rejson/client.py
+++ b/rejson/client.py
@@ -81,6 +81,9 @@ class Client():
     def client(self):
         return self._client
 
+    def execute_command(self, *args, **kwargs):
+        return self.client.execute_command(*args, **kwargs)
+
     def exists(self, *args, **kwargs):
         return self.client.exists(*args, **kwargs)
 
@@ -137,7 +140,7 @@ class Client():
         """
         Deletes the JSON value stored at key ``name`` under ``path``
         """
-        return self.client.execute_command('JSON.DEL', name, str_path(path))
+        return self.execute_command('JSON.DEL', name, str_path(path))
 
     def jsonget(self, name, *args, no_escape=False):
         """
@@ -159,7 +162,7 @@ class Client():
         # Handle case where key doesn't exist. The JSONDecoder would raise a
         # TypeError exception since it can't decode None
         try:
-            return self.client.execute_command('JSON.GET', *pieces)
+            return self.execute_command('JSON.GET', *pieces)
         except TypeError:
             return None
 
@@ -171,7 +174,7 @@ class Client():
         pieces = []
         pieces.extend(args)
         pieces.append(str_path(path))
-        return self.client.execute_command('JSON.MGET', *pieces)
+        return self.execute_command('JSON.MGET', *pieces)
 
     def jsonset(self, name, path, obj, nx=False, xx=False):
         """
@@ -189,41 +192,41 @@ class Client():
             pieces.append('NX')
         elif xx:
             pieces.append('XX')
-        return self.client.execute_command('JSON.SET', *pieces)
+        return self.execute_command('JSON.SET', *pieces)
 
     def jsontype(self, name, path=Path.rootPath()):
         """
         Gets the type of the JSON value under ``path`` from key ``name``
         """
-        return self.client.execute_command('JSON.TYPE', name, str_path(path))
+        return self.execute_command('JSON.TYPE', name, str_path(path))
 
     def jsonnumincrby(self, name, path, number):
         """
         Increments the numeric (integer or floating point) JSON value under
         ``path`` at key ``name`` by the provided ``number``
         """
-        return self.client.execute_command('JSON.NUMINCRBY', name, str_path(path), self._encode(number))
+        return self.execute_command('JSON.NUMINCRBY', name, str_path(path), self._encode(number))
 
     def jsonnummultby(self, name, path, number):
         """
         Multiplies the numeric (integer or floating point) JSON value under
         ``path`` at key ``name`` with the provided ``number``
         """
-        return self.client.execute_command('JSON.NUMMULTBY', name, str_path(path), self._encode(number))
+        return self.execute_command('JSON.NUMMULTBY', name, str_path(path), self._encode(number))
 
     def jsonstrappend(self, name, string, path=Path.rootPath()):
         """
         Appends to the string JSON value under ``path`` at key ``name`` the
         provided ``string``
         """
-        return self.client.execute_command('JSON.STRAPPEND', name, str_path(path), self._encode(string))
+        return self.execute_command('JSON.STRAPPEND', name, str_path(path), self._encode(string))
 
     def jsonstrlen(self, name, path=Path.rootPath()):
         """
         Returns the length of the string JSON value under ``path`` at key
         ``name``
         """
-        return self.client.execute_command('JSON.STRLEN', name, str_path(path))
+        return self.execute_command('JSON.STRLEN', name, str_path(path))
 
     def jsonarrappend(self, name, path=Path.rootPath(), *args):
         """
@@ -233,7 +236,7 @@ class Client():
         pieces = [name, str_path(path)]
         for o in args:
             pieces.append(self._encode(o))
-        return self.client.execute_command('JSON.ARRAPPEND', *pieces)
+        return self.execute_command('JSON.ARRAPPEND', *pieces)
 
     def jsonarrindex(self, name, path, scalar, start=0, stop=-1):
         """
@@ -241,7 +244,7 @@ class Client():
         ``name``. The search can be limited using the optional inclusive
         ``start`` and exclusive ``stop`` indices.
         """
-        return self.client.execute_command('JSON.ARRINDEX', name, str_path(path), self._encode(scalar), start, stop)
+        return self.execute_command('JSON.ARRINDEX', name, str_path(path), self._encode(scalar), start, stop)
 
     def jsonarrinsert(self, name, path, index, *args):
         """
@@ -251,42 +254,42 @@ class Client():
         pieces = [name, str_path(path), index]
         for o in args:
             pieces.append(self._encode(o))
-        return self.client.execute_command('JSON.ARRINSERT', *pieces)
+        return self.execute_command('JSON.ARRINSERT', *pieces)
 
     def jsonarrlen(self, name, path=Path.rootPath()):
         """
         Returns the length of the array JSON value under ``path`` at key
         ``name``
         """
-        return self.client.execute_command('JSON.ARRLEN', name, str_path(path))
+        return self.execute_command('JSON.ARRLEN', name, str_path(path))
 
     def jsonarrpop(self, name, path=Path.rootPath(), index=-1):
         """
         Pops the element at ``index`` in the array JSON value under ``path`` at
         key ``name``
         """
-        return self.client.execute_command('JSON.ARRPOP', name, str_path(path), index)
+        return self.execute_command('JSON.ARRPOP', name, str_path(path), index)
 
     def jsonarrtrim(self, name, path, start, stop):
         """
         Trim the array JSON value under ``path`` at key ``name`` to the 
         inclusive range given by ``start`` and ``stop``
         """
-        return self.client.execute_command('JSON.ARRTRIM', name, str_path(path), start, stop)
+        return self.execute_command('JSON.ARRTRIM', name, str_path(path), start, stop)
 
     def jsonobjkeys(self, name, path=Path.rootPath()):
         """
         Returns the key names in the dictionary JSON value under ``path`` at key
         ``name``
         """
-        return self.client.execute_command('JSON.OBJKEYS', name, str_path(path))
+        return self.execute_command('JSON.OBJKEYS', name, str_path(path))
 
     def jsonobjlen(self, name, path=Path.rootPath()):
         """
         Returns the length of the dictionary JSON value under ``path`` at key
         ``name``
         """
-        return self.client.execute_command('JSON.OBJLEN', name, str_path(path))
+        return self.execute_command('JSON.OBJLEN', name, str_path(path))
 
     def pipeline(self, transaction=True, shard_hint=None):
         """
@@ -315,3 +318,4 @@ class Pipeline(Pipeline, Client):
     def __init__(self, client=None, *args, **kwargs):
         Client.__init__(self, client=client)
         rc.Pipeline.__init__(self, *args, **kwargs)
+

--- a/tests/test_rejson.py
+++ b/tests/test_rejson.py
@@ -15,7 +15,7 @@ class ReJSONTestCase(TestCase):
     def _create_client(self, *args, **kwargs):
         if REDIS_CLUSTER_HOST is None or \
            REDIS_CLUSTER_PORT is None:
-            return Client(port=port, decode_responses=True)
+            return Client(*args, **kwargs)
         else:
             from rediscluster import RedisCluster
             startup_nodes = [{"host": REDIS_CLUSTER_HOST,
@@ -26,7 +26,7 @@ class ReJSONTestCase(TestCase):
 
     def setUp(self):
         global rj
-        rj = self._create_client()
+        rj = self._create_client(port=port, decode_responses=True)
         rj.flushdb()
 
 


### PR DESCRIPTION
Here's a quick implementation, without going into all the details of redis-py/redis-py-cluster. 

Before spending more time on this, it would be useful to hear comments on

1. tests 
2. style/approach. 

## Tests

### Redis

On all my systems, a single failure happens both after and before my edits. Can you confirm/comment?

```bash
Singularity> python -m unittest tests/test_rejson.py 
........F...........
======================================================================
FAIL: testJSONSetGetDelNonAsciiShouldSucceed (tests.test_rejson.ReJSONTestCase)
Test non-ascii JSONSet/Get/Del
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rrs/docks/dev/numericcal/os/redisjson-py/tests/test_rejson.py", line 46, in testJSONSetGetDelNonAsciiShouldSucceed
    self.assertEqual('hyvää-élève', rj.jsonget('notascii'))
AssertionError: 'hyvää-élève' != 'hyvÃ¤Ã¤-Ã©lÃ¨ve'
- hyvää-élève
+ hyvÃ¤Ã¤-Ã©lÃ¨ve


----------------------------------------------------------------------
Ran 20 tests in 0.017s

FAILED (failures=1)
```

### Redis Cluster

The same failure and a few errors. I'm not sure that these should pass for the cluster.
Can you comment?

```bash
Singularity> export REDIS_HOST="localhost"                                                           
Singularity> export REDIS_PORT="6379"                                                                
Singularity> python -m unittest tests/test_rejson.py                                                 
........F.E....E...E                                                                                 
======================================================================                               
ERROR: testMGetShouldSucceed (tests.test_rejson.ReJSONTestCase)                                      
Test JSONMGet                                                                                        
----------------------------------------------------------------------                               
Traceback (most recent call last):                                                                   
  File "/home/rrs/workspace/docks/dev/numericcal/DataKube/gh_deps/redisjson-py/tests/test_rejson.py",
 line 74, in testMGetShouldSucceed                                                                   
    r = rj.jsonmget(Path.rootPath(), '1', '2')                                                       
  File "/home/rrs/workspace/docks/dev/numericcal/DataKube/gh_deps/redisjson-py/rejson/client.py", lin
e 177, in jsonmget                                                                                   
    return self.execute_command('JSON.MGET', *pieces)                                                
  File "/home/rrs/workspace/docks/dev/numericcal/DataKube/gh_deps/redisjson-py/rejson/client.py", lin
e 85, in execute_command                                                                             
    return self.client.execute_command(*args, **kwargs)                                              
  File "/home/rrs/.local/lib/python3.7/site-packages/rediscluster/utils.py", line 101, in inner      
    return func(*args, **kwargs)                                                                     
  File "/home/rrs/.local/lib/python3.7/site-packages/rediscluster/client.py", line 410, in execute_co
mmand                                                                                                
    return self.parse_response(r, command, **kwargs)                                                 
  File "/home/rrs/.local/lib/python3.7/site-packages/redis/client.py", line 768, in parse_response   
    response = connection.read_response()
  File "/home/rrs/.local/lib/python3.7/site-packages/redis/connection.py", line 638, in read_respons$
    raise response
rediscluster.exceptions.ClusterCrossSlotError: Keys in request don't hash to the same slot


======================================================================
ERROR: testPipelineShouldSucceed (tests.test_rejson.ReJSONTestCase)
Test pipeline
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rrs/workspace/docks/dev/numericcal/DataKube/gh_deps/redisjson-py/tests/test_rejson.py"$ line 187, in testPipelineShouldSucceed
    self.assertListEqual([True, 'bar', 1, False], p.execute())
  File "/home/rrs/.local/lib/python3.7/site-packages/redis/client.py", line 3437, in execute
    self.shard_hint)
  File "/home/rrs/.local/lib/python3.7/site-packages/rediscluster/connection.py", line 196, in get_co
nnection
    raise RedisClusterException("Only 'pubsub' commands can be used by get_connection()")
rediscluster.exceptions.RedisClusterException: Only 'pubsub' commands can be used by get_connection()

======================================================================
ERROR: testUsageExampleShouldSucceed (tests.test_rejson.ReJSONTestCase)
Test the usage example
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rrs/workspace/docks/dev/numericcal/DataKube/gh_deps/redisjson-py/tests/test_rejson.py",
 line 270, in testUsageExampleShouldSucceed
    jp.execute()
  File "/home/rrs/.local/lib/python3.7/site-packages/redis/client.py", line 3437, in execute
    self.shard_hint)
  File "/home/rrs/.local/lib/python3.7/site-packages/rediscluster/connection.py", line 196, in get_co
nnection
    raise RedisClusterException("Only 'pubsub' commands can be used by get_connection()")
rediscluster.exceptions.RedisClusterException: Only 'pubsub' commands can be used by get_connection()

======================================================================
FAIL: testJSONSetGetDelNonAsciiShouldSucceed (tests.test_rejson.ReJSONTestCase)
Test non-ascii JSONSet/Get/Del
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rrs/workspace/docks/dev/numericcal/DataKube/gh_deps/redisjson-py/tests/test_rejson.py",
 line 46, in testJSONSetGetDelNonAsciiShouldSucceed
    self.assertEqual('hyvää-élève', rj.jsonget('notascii'))
AssertionError: 'hyvää-élève' != 'hyvÃ¤Ã¤-Ã©lÃ¨ve'
- hyvää-élève
+ hyvÃ¤Ã¤-Ã©lÃ¨ve


----------------------------------------------------------------------
Ran 20 tests in 0.827s

FAILED (failures=1, errors=3)
Singularity>
```